### PR TITLE
Fix default model_dtype

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ DEFAULTS = {
     "compressor": "quant",
     "num_pert": 1,
     "dataset": "mnist",
-    "model_dtype": "float16",
+    "model_dtype": "float32",
     "momentum": 0.9,
     "warmup_epochs": 5,
     "adjust_perturb": False,

--- a/preprocess.py
+++ b/preprocess.py
@@ -34,11 +34,15 @@ def use_device(args):
         }
     elif use_mps:
         print("----- Using mps -----")
+        print("----- Forcing model_dtype = float32 -----")
+        args.model_dtype = "float32"
         kwargs = {}
         server_device = {"server": torch.device("mps")}
         client_devices = {get_client_name(i): torch.device("mps") for i in range(num_clients)}
     else:
         print("----- Using cpu -----")
+        print("----- Forcing model_dtype = float32 -----")
+        args.model_dtype = "float32"
         kwargs = {}
         server_device = {"server": torch.device("cpu")}
         client_devices = {get_client_name(i): torch.device("cpu") for i in range(num_clients)}


### PR DESCRIPTION
https://stackoverflow.com/questions/62112534/fp16-inference-on-cpu-pytorch

Float16 is not supported by cpu and mps.

Also it's more likely to use float16 when trying to work with large model