### PR TITLE
Multi-threading debugging and test

### DIFF
--- a/cezo_fl/client.py
+++ b/cezo_fl/client.py
@@ -64,14 +64,17 @@ class SyncClient(AbstractClient):
             self.optimizer.zero_grad()
             # NOTE:dataloader manage its own randomnes state thus not affected by seed
             batch_inputs, labels = next(self.data_iterator)
-            if self.device != torch.device("cpu") or self.grad_estimator.torch_dtype != torch.float32:
-                batch_inputs= batch_inputs.to(self.device, self.grad_estimator.torch_dtype)
-                ## NOTE: label does not convert to dtype
+            if (
+                self.device != torch.device("cpu")
+                or self.grad_estimator.torch_dtype != torch.float32
+            ):
+                batch_inputs = batch_inputs.to(self.device, self.grad_estimator.torch_dtype)
+                # NOTE: label does not convert to dtype
                 labels = labels.to(self.device)
 
+            rng = torch.Generator(device=self.device).manual_seed(seed)
             # generate grads and update model's gradient
-            torch.manual_seed(seed)
-            seed_grads = self.grad_estimator.compute_grad(batch_inputs, labels, self.criterion)
+            seed_grads = self.grad_estimator.compute_grad(batch_inputs, labels, self.criterion, rng)
             iteration_local_update_grad_vectors.append(seed_grads)
 
             # update model
@@ -179,14 +182,17 @@ class ResetClient(AbstractClient):
             self.optimizer.zero_grad()
             # NOTE:dataloader manage its own randomnes state thus not affected by seed
             batch_inputs, labels = next(self.data_iterator)
-            if self.device != torch.device("cpu") or self.grad_estimator.torch_dtype != torch.float32:
+            if (
+                self.device != torch.device("cpu")
+                or self.grad_estimator.torch_dtype != torch.float32
+            ):
                 batch_inputs = batch_inputs.to(self.device, self.grad_estimator.torch_dtype)
-                ## NOTE: label does not convert to dtype
+                # NOTE: label does not convert to dtype
                 labels = labels.to(self.device)
 
+            rng = torch.Generator(device=self.device).manual_seed(seed)
             # generate grads and update model's gradient
-            torch.manual_seed(seed)
-            seed_grads = self.grad_estimator.compute_grad(batch_inputs, labels, self.criterion)
+            seed_grads = self.grad_estimator.compute_grad(batch_inputs, labels, self.criterion, rng)
             iteration_local_update_grad_vectors.append(seed_grads)
 
             # update model

--- a/cezo_fl/client.py
+++ b/cezo_fl/client.py
@@ -72,7 +72,7 @@ class SyncClient(AbstractClient):
         optimizer: torch.optim.Optimizer,
         criterion: CriterionType,
         accuracy_func,
-        device: str | None = None,
+        device: torch.device | None = None,
     ):
         self.model = model
         self.dataloader = dataloader
@@ -192,7 +192,7 @@ class ResetClient(AbstractClient):
         optimizer: torch.optim.Optimizer,
         criterion: CriterionType,
         accuracy_func,
-        device: str | None = None,
+        device: torch.device | None = None,
     ):
         self.model = model
         self.dataloader = dataloader

--- a/cezo_fl/client.py
+++ b/cezo_fl/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import torch
 from torch.utils.data import DataLoader
-from typing import Sequence
+from typing import Sequence, Iterator
 from copy import deepcopy
 import abc
 from dataclasses import dataclass
@@ -89,13 +89,13 @@ class SyncClient(AbstractClient):
         self.local_update_seeds: list[int] = []
         self.local_update_dir_grads: list[torch.Tensor] = []
 
-    def _get_train_batch_iterator(self):
+    def _get_train_batch_iterator(self) -> Iterator:
         # NOTE: used only in init, will generate an infinite iterator from dataloader
         while True:
             for v in self.dataloader:
                 yield v
 
-    def random_gradient_estimator(self):
+    def random_gradient_estimator(self) -> RGE:
         return self.grad_estimator
 
     def local_update(self, seeds: Sequence[int]) -> LocalUpdateResult:
@@ -207,10 +207,10 @@ class ResetClient(AbstractClient):
         self.data_iterator = self._get_train_batch_iterator()
         self.last_pull_state_dict = self.screenshot()
 
-    def random_gradient_estimator(self):
+    def random_gradient_estimator(self) -> RGE:
         return self.grad_estimator
 
-    def _get_train_batch_iterator(self):
+    def _get_train_batch_iterator(self) -> Iterator:
         # NOTE: used only in init, will generate an infinite iterator from dataloader
         while True:
             for v in self.dataloader:

--- a/cezo_fl/client.py
+++ b/cezo_fl/client.py
@@ -30,6 +30,10 @@ class LocalUpdateResult:
 
 class AbstractClient:
 
+    @abc.abstractproperty
+    def device(self) -> torch.device:
+        return torch.device(self._device)
+
     @abc.abstractmethod
     def local_update(self, seeds: Sequence[int]) -> LocalUpdateResult:
         """Returns a sequence of gradient scalar tensors for each local update.
@@ -73,7 +77,7 @@ class SyncClient(AbstractClient):
         self.model = model
         self.dataloader = dataloader
 
-        self.device = device
+        self._device = device
 
         self.grad_estimator = grad_estimator
         self.optimizer = optimizer
@@ -193,7 +197,7 @@ class ResetClient(AbstractClient):
         self.model = model
         self.dataloader = dataloader
 
-        self.device = device
+        self._device = device
 
         self.grad_estimator = grad_estimator
         self.optimizer = optimizer

--- a/cezo_fl/run_client_jobs.py
+++ b/cezo_fl/run_client_jobs.py
@@ -41,7 +41,7 @@ def parallalizable_client_job(
     return client_local_update_result.to(server_device)
 
 
-# Outer list is for clients and inner list for local update date
+# Outer list is for clients and inner list for local update data
 LOCAL_GRAD_SCALAR_LIST: TypeAlias = list[list[torch.Tensor]]
 
 

--- a/cezo_fl/run_client_jobs.py
+++ b/cezo_fl/run_client_jobs.py
@@ -1,0 +1,98 @@
+import torch
+from typing import Sequence, TypeAlias
+from concurrent.futures import ThreadPoolExecutor
+from asyncio.futures import Future
+
+from shared.metrics import Metric
+from cezo_fl.client import SyncClient, ResetClient, LocalUpdateResult
+
+
+def parallalizable_client_job(
+    client: SyncClient | ResetClient,
+    pull_seeds_list: Sequence[Sequence[int]],
+    pull_grad_list: Sequence[Sequence[torch.Tensor]],
+    local_update_seeds: Sequence[int],
+    server_device: torch.device,
+) -> LocalUpdateResult:
+    """
+    Run client pull and local update in parallel.
+    This function is added to make better use of multi-gpu set up.
+    Each client can be deployed to a separate gpu. Thus we can run all clients in parallel.
+
+    Note:
+    This function also make sure the data passed to/from client are converted to correct device.
+    We should only do cross device operation here
+    """
+    # need no_grad because the outer-most no_grad context manager does not affect
+    # operation inside sub-thread
+    with torch.no_grad():
+        # step 1 map pull_grad_list data to client's device
+
+        transfered_grad_list = [
+            [tensor.to(client.device) for tensor in tensors] for tensors in pull_grad_list
+        ]
+
+        # step 2, client pull to update its model to latest
+        client.pull_model(pull_seeds_list, transfered_grad_list)
+
+        # step 3, client local update and get its result
+        client_local_update_result = client.local_update(seeds=local_update_seeds)
+
+    # move result to server device and return
+    return client_local_update_result.to(server_device)
+
+
+LOCAL_GRAD_SCALAR_LIST: TypeAlias = list[list[torch.Tensor]]
+
+
+def execute_sampled_clients(
+    server, sampled_client_index, seeds, *, parallel: bool = False
+) -> tuple[Metric, Metric, LOCAL_GRAD_SCALAR_LIST]:
+    local_grad_scalar_list: LOCAL_GRAD_SCALAR_LIST = []  # Clients X Local_update
+    step_train_loss = Metric("Step train loss")
+    step_train_accuracy = Metric("Step train accuracy")
+
+    if parallel:
+        with ThreadPoolExecutor() as executor:
+            futures: list[Future] = []
+            for index in sampled_client_index:
+                client = server.clients[index]
+                last_update_iter = server.client_last_updates[index]
+                # The seed and grad in last_update_iter is fetched as well
+                # Note at that iteration, we just reset the client model so that iteration
+                # information is needed as well.
+                seeds_list = server.seed_grad_records.fetch_seed_records(last_update_iter)
+                grad_list = server.seed_grad_records.fetch_grad_records(last_update_iter)
+
+                futures.append(
+                    executor.submit(
+                        parallalizable_client_job,
+                        client,
+                        seeds_list,
+                        grad_list,
+                        seeds,
+                        server.device,
+                    )
+                )
+
+            client_results = [f.result(timeout=1e4) for f in futures]
+    else:
+        client_results = []
+        for index in sampled_client_index:
+            client = server.clients[index]
+            last_update_iter = server.client_last_updates[index]
+            # The seed and grad in last_update_iter is fetched as well
+            # Note at that iteration, we just reset the client model so that iteration
+            # information is needed as well.
+            seeds_list = server.seed_grad_records.fetch_seed_records(last_update_iter)
+            grad_list = server.seed_grad_records.fetch_grad_records(last_update_iter)
+            client_results.append(
+                parallalizable_client_job(client, seeds_list, grad_list, seeds, server.device)
+            )
+
+    for client_local_update_result in client_results:
+        step_train_loss.update(client_local_update_result.step_loss)
+        step_train_accuracy.update(client_local_update_result.step_accuracy)
+        local_grad_scalar_list.append(client_local_update_result.grad_tensors)
+
+    return step_train_loss, step_train_accuracy, local_grad_scalar_list

--- a/cezo_fl/run_client_jobs_test.py
+++ b/cezo_fl/run_client_jobs_test.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock
+import pytest
+import torch
+
+
+from cezo_fl.client import SyncClient
+from cezo_fl.run_client_jobs import parallalizable_client_job, execute_sampled_clients
+from models.cnn_mnist import CNN_MNIST
+from config import FakeArgs
+from preprocess import preprocess
+from gradient_estimators.random_gradient_estimator import RandomGradientEstimator as RGE
+from torch.optim import SGD
+from shared.metrics import accuracy
+from copy import deepcopy
+
+
+def set_fake_clients() -> list[SyncClient]:
+    args = FakeArgs()
+    args.dataset = "mnist"
+    args.num_clients = 3
+    args.num_pert = 4
+    args.local_update_steps = 2
+
+    device_map, train_loaders, _ = preprocess(args)
+    device = device_map["server"]
+    fake_clients = []
+    for i in range(args.num_clients):
+        torch.random.manual_seed(1234)  # Make sure all models are the same
+        model = CNN_MNIST().to(device)
+        train_loader = train_loaders[0]
+        grad_estimator = RGE(
+            model,
+            mu=1e-3,
+            num_pert=2,
+            grad_estimate_method="forward",
+            device=device,
+        )
+        optimizer = SGD(model.parameters(), lr=args.lr, weight_decay=0)
+        criterion = torch.nn.CrossEntropyLoss()
+        fake_clients.append(
+            SyncClient(
+                model=model,
+                dataloader=train_loader,
+                grad_estimator=grad_estimator,
+                optimizer=optimizer,
+                criterion=criterion,
+                accuracy_func=accuracy,
+                device=device,
+            )
+        )
+    return fake_clients
+
+
+def test_parallalizable_client_job_identical():
+    fake_clients = set_fake_clients()
+    # Note in the fake_client setup, we choose local_update=2, clients=3, and num_pert=4
+    # We need to make sure each job runs on are completely independent.
+    pull_seeds_list = [[1, 2], [1, 2], [1, 2]]
+    pull_grad_list = [
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+    ]
+    results = []
+    for fake_client in fake_clients:
+        results.append(
+            parallalizable_client_job(
+                fake_client,
+                pull_seeds_list,
+                pull_grad_list,
+                local_update_seeds=[7, 8],
+                server_device=torch.device("cpu"),
+            )
+        )
+        print(results[-1])
+    # Because we give the same model, same seed and grad scalar,  the local update must be the same.
+    for i in range(2):  # local_update
+        assert (results[0].grad_tensors[i] - results[1].grad_tensors[i]).abs().max() < 1e-6
+        assert (results[1].grad_tensors[i] - results[2].grad_tensors[i]).abs().max() < 1e-6
+
+    assert abs(results[0].step_accuracy - results[1].step_accuracy) < 1e-6
+    assert abs(results[1].step_accuracy - results[2].step_accuracy) < 1e-6
+
+    assert abs(results[0].step_loss - results[1].step_loss) < 1e-6
+    assert abs(results[1].step_loss - results[2].step_loss) < 1e-6
+
+
+def test_execute_sampled_clients_parallabel():
+    server = MagicMock()
+    server.device = "cpu"
+    server.client_last_updates = [0, 0, 0]
+    server.seed_grad_records.fetch_seed_records.return_value = [[1, 2], [1, 2], [1, 2]]
+    server.seed_grad_records.fetch_grad_records.return_value = [
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+    ]
+
+    for _ in range(10):  # Try multiple time
+        server.clients = set_fake_clients()
+        serialized_result = execute_sampled_clients(
+            server, sampled_client_index=[0, 1, 2], seeds=[7, 8], parallel=False
+        )
+        server.clients = set_fake_clients()  # Reset client
+        parallel_result = execute_sampled_clients(
+            server, sampled_client_index=[0, 1, 2], seeds=[7, 8], parallel=True
+        )
+        # result is (step_train_loss, step_train_accuracy, local_grad_scalar_list)
+        assert abs(serialized_result[0].avg - parallel_result[0].avg) < 1e-5
+        assert abs(serialized_result[1].avg - parallel_result[1].avg) < 1e-5
+
+        for s_local_grad, p_local_grad in zip(serialized_result[2], parallel_result[2]):
+            for s_local_grad_one_step, p_local_grad_one_step in zip(s_local_grad, p_local_grad):
+                assert (s_local_grad_one_step - p_local_grad_one_step).abs().max() < 1e-5

--- a/cezo_fl/run_client_jobs_test.py
+++ b/cezo_fl/run_client_jobs_test.py
@@ -1,9 +1,11 @@
 from unittest.mock import MagicMock
 import pytest
 import torch
+import torchvision
+import torchvision.transforms as transforms
+import numpy as np
 
-
-from cezo_fl.client import SyncClient
+from cezo_fl.client import ResetClient
 from cezo_fl.run_client_jobs import parallalizable_client_job, execute_sampled_clients
 from models.cnn_mnist import CNN_MNIST
 from config import FakeArgs
@@ -11,23 +13,33 @@ from preprocess import preprocess
 from gradient_estimators.random_gradient_estimator import RandomGradientEstimator as RGE
 from torch.optim import SGD
 from shared.metrics import accuracy
-from copy import deepcopy
 
 
-def set_fake_clients() -> list[SyncClient]:
+def get_mnist_data_loader():
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
+    train_dataset = torchvision.datasets.MNIST(
+        root="./data", train=True, download=True, transform=transform
+    )
+
+    return torch.utils.data.DataLoader(train_dataset, batch_size=8, shuffle=False)
+
+
+def set_fake_clients(num_clients=3, num_pert=4, local_update_steps=2) -> list[ResetClient]:
     args = FakeArgs()
     args.dataset = "mnist"
-    args.num_clients = 3
-    args.num_pert = 4
-    args.local_update_steps = 2
+    args.num_clients = num_clients
+    args.num_pert = num_pert
+    args.local_update_steps = local_update_steps
 
-    device_map, train_loaders, _ = preprocess(args)
+    device_map, _, _ = preprocess(args)
     device = device_map["server"]
     fake_clients = []
     for i in range(args.num_clients):
         torch.random.manual_seed(1234)  # Make sure all models are the same
         model = CNN_MNIST().to(device)
-        train_loader = train_loaders[0]
+        train_loader = get_mnist_data_loader()
         grad_estimator = RGE(
             model,
             mu=1e-3,
@@ -38,7 +50,7 @@ def set_fake_clients() -> list[SyncClient]:
         optimizer = SGD(model.parameters(), lr=args.lr, weight_decay=0)
         criterion = torch.nn.CrossEntropyLoss()
         fake_clients.append(
-            SyncClient(
+            ResetClient(
                 model=model,
                 dataloader=train_loader,
                 grad_estimator=grad_estimator,
@@ -85,25 +97,65 @@ def test_parallalizable_client_job_identical():
     assert abs(results[1].step_loss - results[2].step_loss) < 1e-6
 
 
-def test_execute_sampled_clients_parallabel():
+@pytest.mark.parametrize(
+    "num_clients, num_pert, local_update_steps",
+    [
+        (1, 1, 1),
+        (1, 1, 3),
+        (1, 1, 5),
+        (1, 3, 1),
+        (1, 3, 3),
+        (1, 3, 5),
+        (1, 5, 1),
+        (1, 5, 3),
+        (1, 5, 5),
+        (3, 1, 1),
+        (3, 1, 3),
+        (3, 1, 5),
+        (3, 3, 1),
+        (3, 3, 3),
+        (3, 3, 5),
+        (3, 5, 1),
+        (3, 5, 3),
+        (3, 5, 5),
+        (5, 1, 1),
+        (5, 1, 3),
+        (5, 1, 5),
+        (5, 3, 1),
+        (5, 3, 3),
+        (5, 3, 5),
+        (5, 5, 1),
+        (5, 5, 3),
+        (5, 5, 5),
+    ],
+)
+def test_execute_sampled_clients_parallabel(num_clients, num_pert, local_update_steps):
     server = MagicMock()
-    server.device = "cpu"
-    server.client_last_updates = [0, 0, 0]
-    server.seed_grad_records.fetch_seed_records.return_value = [[1, 2], [1, 2], [1, 2]]
+    server.device = torch.device("cpu")
+    server.client_last_updates = [0 for _ in range(num_clients)]
+    existing_iteration = 3
+    server.seed_grad_records.fetch_seed_records.return_value = np.random.randint(
+        0, 100, (existing_iteration, local_update_steps)
+    ).tolist()
     server.seed_grad_records.fetch_grad_records.return_value = [
-        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
-        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
-        [torch.tensor([1, 1, 1, 1]), torch.tensor([-1, -1, -1, -1])],
+        [torch.randn(num_pert) for _ in range(local_update_steps)]
+        for _ in range(existing_iteration)
     ]
 
-    for _ in range(10):  # Try multiple time
-        server.clients = set_fake_clients()
+    for _ in range(3):  # Try multiple time
+        server.clients = set_fake_clients(num_clients, num_pert, local_update_steps)
+
+        sampled_index = np.random.choice(
+            [i for i in range(num_clients)], (num_clients + 1) // 2, replace=False
+        ).tolist()
+        seeds = np.random.randint(1, 100, local_update_steps).tolist()
+
         serialized_result = execute_sampled_clients(
-            server, sampled_client_index=[0, 1, 2], seeds=[7, 8], parallel=False
+            server, sampled_client_index=sampled_index, seeds=seeds, parallel=False
         )
-        server.clients = set_fake_clients()  # Reset client
+        server.clients = set_fake_clients(num_clients, num_pert, local_update_steps)  # Reset client
         parallel_result = execute_sampled_clients(
-            server, sampled_client_index=[0, 1, 2], seeds=[7, 8], parallel=True
+            server, sampled_client_index=sampled_index, seeds=seeds, parallel=True
         )
         # result is (step_train_loss, step_train_accuracy, local_grad_scalar_list)
         assert abs(serialized_result[0].avg - parallel_result[0].avg) < 1e-5

--- a/cezo_fl/server.py
+++ b/cezo_fl/server.py
@@ -1,57 +1,13 @@
-from __future__ import annotations
-import abc
 import random
 import torch
 from typing import Any, Iterable, Sequence
 from collections import deque
 
-from concurrent.futures import ThreadPoolExecutor
 from cezo_fl.shared import CriterionType, update_model_given_seed_and_grad
+from cezo_fl.client import ResetClient, SyncClient
+from cezo_fl.run_client_jobs import execute_sampled_clients
 from shared.metrics import Metric
 from gradient_estimators.random_gradient_estimator import RandomGradientEstimator as RGE
-from dataclasses import dataclass
-
-
-@dataclass
-class LocalUpdateResult:
-    grad_tensors: list[torch.Tensor]
-    step_accuracy: float
-    step_loss: float
-
-    # Must add __future__ import to be able to return, see https://stackoverflow.com/a/33533514
-    def to(self, device: torch.device) -> LocalUpdateResult:
-        self.grad_tensors = [grad_tensor.to(device) for grad_tensor in self.grad_tensors]
-        return self
-
-
-class AbstractClient:
-
-    @abc.abstractmethod
-    def local_update(self, seeds: Sequence[int]) -> LocalUpdateResult:
-        """Returns a sequence of gradient scalar tensors for each local update.
-
-        The length of the returned sequence should be the same as the length of seeds.
-        The inner tensor can be a scalar or a vector. The length of vector is the number
-        of perturbations.
-        """
-        return NotImplemented
-
-    @abc.abstractmethod
-    def reset_model(self) -> None:
-        """Reset the mode to the state before the local_update."""
-        return NotImplemented
-
-    @abc.abstractmethod
-    def pull_model(
-        self,
-        seeds_list: Sequence[Sequence[int]],
-        gradient_scalar: Sequence[Sequence[torch.Tensor]],
-    ) -> None:
-        return NotImplemented
-
-    @abc.abstractmethod
-    def random_gradient_estimator(self) -> RGE:
-        return NotImplemented
 
 
 class SeedAndGradientRecords:
@@ -100,47 +56,12 @@ class SeedAndGradientRecords:
         ]
 
 
-def parallalizable_client_job(
-    client: AbstractClient,
-    pull_seeds_list: Sequence[Sequence[int]],
-    pull_grad_list: Sequence[Sequence[torch.Tensor]],
-    local_update_seeds: Sequence[int],
-    server_device: torch.device,
-) -> LocalUpdateResult:
-    """
-    Run client pull and local update in parallel.
-    This function is added to make better use of multi-gpu set up.
-    Each client can be deployed to a separate gpu. Thus we can run all clients in parallel.
-
-    Note:
-    This function also make sure the data passed to/from client are converted to correct device.
-    We should only do cross device operation here
-    """
-    # need no_grad because the outer-most no_grad context manager does not affect
-    # operation inside sub-thread
-    with torch.no_grad():
-        # step 1 map pull_grad_list data to client's device
-
-        transfered_grad_list = [
-            [tensor.to(client.device) for tensor in tensors] for tensors in pull_grad_list
-        ]
-
-        # step 2, client pull to update its model to latest
-        client.pull_model(pull_seeds_list, transfered_grad_list)
-
-        # step 3, client local update and get its result
-        client_local_update_result = client.local_update(seeds=local_update_seeds)
-
-    # move result to server device and return
-    return client_local_update_result.to(server_device)
-
-
 # TODO Make sure all client model intialized with same weight.
 # TODO Support Gradient Pruning
 class CeZO_Server:
     def __init__(
         self,
-        clients: Sequence[AbstractClient],
+        clients: Sequence[ResetClient | SyncClient],
         device: torch.device,
         num_sample_clients: int = 10,
         local_update_steps: int = 10,
@@ -200,37 +121,15 @@ class CeZO_Server:
         seeds = [random.randint(0, 1000000) for _ in range(self.local_update_steps)]
 
         # Step 1 & 2: pull model and local update
-        local_grad_scalar_list: list[list[torch.Tensor]] = []  # Clients X Local_update
-        step_train_loss = Metric("Step train loss")
-        step_train_accuracy = Metric("Step train accuracy")
-
-        with ThreadPoolExecutor() as executor:
-            futures: list[futures.Futures] = []
-            for index in sampled_client_index:
-                client = self.clients[index]
-                last_update_iter = self.client_last_updates[index]
-                # The seed and grad in last_update_iter is fetched as well
-                # Note at that iteration, we just reset the client model so that iteration
-                # information is needed as well.
-                seeds_list = self.seed_grad_records.fetch_seed_records(last_update_iter)
-                grad_list = self.seed_grad_records.fetch_grad_records(last_update_iter)
-
-                futures.append(
-                    executor.submit(
-                        parallalizable_client_job, client, seeds_list, grad_list, seeds, self.device
-                    )
-                )
-
-            client_results = [f.result(timeout=1e4) for f in futures]
-
-        for index, client_local_update_result in zip(sampled_client_index, client_results):
-            step_train_loss.update(client_local_update_result.step_loss)
-            step_train_accuracy.update(client_local_update_result.step_accuracy)
-            local_grad_scalar_list.append(client_local_update_result.grad_tensors)
-            self.client_last_updates[index] = iteration
+        step_train_loss, step_train_accuracy, local_grad_scalar_list = execute_sampled_clients(
+            self, sampled_client_index, seeds, parallel=True
+        )
 
         # Step 3: server-side aggregation
         avg_grad_scalar: list[torch.Tensor] = []
+        for index in sampled_client_index:
+            self.client_last_updates[index] = iteration
+
         for each_client_update in zip(*local_grad_scalar_list):
             avg_grad_scalar.append(sum(each_client_update).div_(self.num_sample_clients))
 
@@ -242,6 +141,8 @@ class CeZO_Server:
 
         if self.server_model:
             self.train()
+            assert self.optim
+            assert self.random_gradient_estimator
             update_model_given_seed_and_grad(
                 self.optim,
                 self.random_gradient_estimator,
@@ -254,6 +155,10 @@ class CeZO_Server:
     def eval_model(self, test_loader: Iterable[Any]) -> tuple[float, float]:
         if self.server_model is None:
             raise RuntimeError("set_server_model_and_criterion for server first.")
+        assert self.random_gradient_estimator
+        assert self.server_criterion
+        assert self.server_accuracy_func
+
         self.server_model.eval()
         eval_loss = Metric("Eval loss")
         eval_accuracy = Metric("Eval accuracy")

--- a/cezo_fl/server.py
+++ b/cezo_fl/server.py
@@ -122,7 +122,7 @@ class CeZO_Server:
 
         # Step 1 & 2: pull model and local update
         step_train_loss, step_train_accuracy, local_grad_scalar_list = execute_sampled_clients(
-            self, sampled_client_index, seeds, parallel=True
+            self, sampled_client_index, seeds, parallel=False
         )
 
         # Step 3: server-side aggregation

--- a/cezo_fl/server.py
+++ b/cezo_fl/server.py
@@ -4,7 +4,7 @@ from typing import Any, Iterable, Sequence
 from collections import deque
 
 from cezo_fl.shared import CriterionType, update_model_given_seed_and_grad
-from cezo_fl.client import ResetClient, SyncClient
+from cezo_fl.client import AbstractClient
 from cezo_fl.run_client_jobs import execute_sampled_clients
 from shared.metrics import Metric
 from gradient_estimators.random_gradient_estimator import RandomGradientEstimator as RGE
@@ -61,7 +61,7 @@ class SeedAndGradientRecords:
 class CeZO_Server:
     def __init__(
         self,
-        clients: Sequence[ResetClient | SyncClient],
+        clients: Sequence[AbstractClient],
         device: torch.device,
         num_sample_clients: int = 10,
         local_update_steps: int = 10,

--- a/cezo_fl/server_test.py
+++ b/cezo_fl/server_test.py
@@ -51,6 +51,9 @@ def test_update_model_given_seed_and_grad():
 
 
 class FakeClient(AbstractClient):
+    def __init__(self):
+        self._device = torch.device("cpu")
+
     def local_update(self, seeds: Sequence[int]) -> LocalUpdateResult:
         return LocalUpdateResult(
             grad_tensors=[torch.tensor([0.1, 0.2, 0.3]) for _ in range(len(seeds))],

--- a/cezo_fl/server_test.py
+++ b/cezo_fl/server_test.py
@@ -1,10 +1,6 @@
-from cezo_fl.server import (
-    AbstractClient,
-    LocalUpdateResult,
-    CeZO_Server,
-    SeedAndGradientRecords,
-    update_model_given_seed_and_grad,
-)
+from cezo_fl.server import CeZO_Server, SeedAndGradientRecords, update_model_given_seed_and_grad
+from cezo_fl.client import AbstractClient, LocalUpdateResult
+
 from typing import Sequence
 from unittest.mock import MagicMock, patch
 from gradient_estimators.random_gradient_estimator import RandomGradientEstimator as RGE

--- a/cezo_fl/shared.py
+++ b/cezo_fl/shared.py
@@ -8,10 +8,11 @@ CriterionType: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 def get_update_grad_for_1_seed(grad_estimator: RGE, perturb_grad_vector: torch.Tensor, seed: int):
-    torch.manual_seed(seed)
+    # 1 seed is in charge all perturbs
+    rng = torch.Generator(device=grad_estimator.device).manual_seed(seed)
     update_grad = None
     for local_update_grad in perturb_grad_vector:
-        perturb = grad_estimator.generate_perturbation_norm()
+        perturb = grad_estimator.generate_perturbation_norm(rng)
         if update_grad is None:
             update_grad = perturb.mul_(local_update_grad)
         else:


### PR DESCRIPTION
## Summary 

- [x] use rng directly in torch.randn instead of relying on the global rng state
- [x] refactor server train one step to make it more readable
- [x] add option in server to switch between 1-by-1 and multi-thread
- [x] test 2 options under 1/5/10 perturb, 1/3/5 local updates, 1/3/5 clients. They should give same result

## Result

Before PR:
![image](https://github.com/user-attachments/assets/ca947ca9-2542-4037-bcf6-16097a4c4b3f)

After PR: 
![image](https://github.com/user-attachments/assets/4e9c0582-bc65-4dc9-bf1c-0da6ce4f990d)

## Test

![image](https://github.com/user-attachments/assets/77b88e9f-1740-4207-9068-ea1bcff1c4a8)
